### PR TITLE
Consolidate monitoring actions into a unified class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@
    - ✅ Refactor 57-line ExecuteDeviceAction method
    - ✅ Extract special handling for ResetCypressDeviceAction
 
-3. Consolidate nearly identical implementations:
-   - MonitorCardReads.cs and MonitorKeyPadReads.cs
+3. ✅ Consolidate nearly identical implementations:
+   - ✅ MonitorCardReads.cs and MonitorKeyPadReads.cs replaced with unified MonitoringAction.cs
 
 4. Test improvements:
    - ✅ Increase test coverage for ConnectViewModel (Completed in PR feature/refactor-connect-viewmodel)

--- a/src/Core/Actions/MonitoringAction.cs
+++ b/src/Core/Actions/MonitoringAction.cs
@@ -1,0 +1,96 @@
+﻿using OSDP.Net;
+
+namespace OSDPBench.Core.Actions;
+
+/// <summary>
+/// Represents a device action that monitors various input types from a device.
+/// </summary>
+public class MonitoringAction : IDeviceAction
+{
+    private readonly string _name;
+    
+    /// <summary>
+    /// Gets the type of monitoring being performed.
+    /// </summary>
+    public MonitoringType MonitoringType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MonitoringAction"/> class.
+    /// </summary>
+    /// <param name="monitoringType">The type of monitoring to perform.</param>
+    public MonitoringAction(MonitoringType monitoringType)
+    {
+        MonitoringType = monitoringType;
+        _name = monitoringType switch
+        {
+            MonitoringType.CardReads => "Monitor Card Reads",
+            MonitoringType.KeypadReads => "Monitor Keypad Reads",
+            _ => "Monitor Device"
+        };
+    }
+
+    /// <inheritdoc />
+    public string Name => _name;
+
+    /// <inheritdoc />
+    public string PerformActionName => string.Empty;
+
+    /// <inheritdoc />
+    public async Task<object> PerformAction(ControlPanel panel, Guid connectionId, byte address, object? parameter)
+    {
+        return await Task.FromResult(true);
+    }
+}
+
+/// <summary>
+/// Defines the type of monitoring to perform on a device.
+/// </summary>
+public enum MonitoringType
+{
+    /// <summary>
+    /// Monitors card read events.
+    /// </summary>
+    CardReads,
+    
+    /// <summary>
+    /// Monitors keypad input events.
+    /// </summary>
+    KeypadReads
+}
+
+/// <summary>
+/// Extension methods for IDeviceAction that simplify working with monitoring actions.
+/// </summary>
+public static class DeviceActionExtensions
+{
+    /// <summary>
+    /// Determines if the device action is a monitoring action of the specified type.
+    /// </summary>
+    /// <param name="action">The device action to check.</param>
+    /// <param name="monitoringType">The monitoring type to check for.</param>
+    /// <returns>True if the action is a monitoring action of the specified type; otherwise, false.</returns>
+    public static bool IsMonitoringAction(this IDeviceAction action, MonitoringType monitoringType)
+    {
+        return action is MonitoringAction monitoringAction && monitoringAction.MonitoringType == monitoringType;
+    }
+    
+    /// <summary>
+    /// Determines if the device action is for monitoring card reads.
+    /// </summary>
+    /// <param name="action">The device action to check.</param>
+    /// <returns>True if the action is for monitoring card reads; otherwise, false.</returns>
+    public static bool IsCardReadsMonitor(this IDeviceAction action)
+    {
+        return action.IsMonitoringAction(MonitoringType.CardReads);
+    }
+    
+    /// <summary>
+    /// Determines if the device action is for monitoring keypad reads.
+    /// </summary>
+    /// <param name="action">The device action to check.</param>
+    /// <returns>True if the action is for monitoring keypad reads; otherwise, false.</returns>
+    public static bool IsKeypadReadsMonitor(this IDeviceAction action)
+    {
+        return action.IsMonitoringAction(MonitoringType.KeypadReads);
+    }
+}

--- a/src/Core/ViewModels/Pages/ManageViewModel.cs
+++ b/src/Core/ViewModels/Pages/ManageViewModel.cs
@@ -268,8 +268,8 @@ public partial class ManageViewModel : ObservableObject
     [
         new ControlBuzzerAction(),
         new FileTransferAction(),
-        new MonitorCardReads(), 
-        new MonitorKeypadReads(),
+        new MonitoringAction(MonitoringType.CardReads),
+        new MonitoringAction(MonitoringType.KeypadReads),
         new ResetCypressDeviceAction(), 
         new SetCommunicationAction(),
         new SetReaderLedAction()

--- a/src/UI/Windows/Views/Pages/ManagePage.xaml.cs
+++ b/src/UI/Windows/Views/Pages/ManagePage.xaml.cs
@@ -34,43 +34,47 @@ public partial class ManagePage : INavigableView<ManageViewModel>
     {
         DeviceActionControl.Children.Clear();
             
-        switch (DeviceActionsComboBox.SelectedValue)
+        if (ViewModel.ConnectedPortName == null)
         {
-            case ControlBuzzerAction when ViewModel.ConnectedPortName != null:
-            {
+            return;
+        }
+        
+        var selectedAction = DeviceActionsComboBox.SelectedValue as IDeviceAction;
+
+        switch (selectedAction)
+        {
+            case ControlBuzzerAction:
                 ControlBuzzerControl();
                 break;
-            }
-            case FileTransferAction when ViewModel.ConnectedPortName != null:
-            {
+                
+            case FileTransferAction:
                 FileTransferControl();
                 break;
-            }
-            case MonitorCardReads when ViewModel.ConnectedPortName != null:
-            {
-                MonitorCardReadsControl();
+                
+            case MonitoringAction monitoringAction:
+                switch (monitoringAction.MonitoringType)
+                {
+                    case MonitoringType.CardReads:
+                        MonitorCardReadsControl();
+                        break;
+                        
+                    case MonitoringType.KeypadReads:
+                        MonitorKeypadReadsControl();
+                        break;
+                }
                 break;
-            }
-            case MonitorKeypadReads when ViewModel.ConnectedPortName != null:
-            {
-                MonitorKeypadReadsControl();
-                break;
-            }
-            case ResetCypressDeviceAction when ViewModel.ConnectedPortName != null:
-            {
+                
+            case ResetCypressDeviceAction:
                 ResetControl();
                 break;
-            }
-            case SetCommunicationAction when ViewModel.ConnectedPortName != null:
-            {
+                
+            case SetCommunicationAction:
                 SetCommunicationActionControl();
                 break;
-            }
-            case SetReaderLedAction when ViewModel.ConnectedPortName != null:
-            {
+                
+            case SetReaderLedAction:
                 SetReaderLedActionControl();
                 break;
-            }
         }
     }
 

--- a/test/Core.Tests/Actions/MonitoringActionTests.cs
+++ b/test/Core.Tests/Actions/MonitoringActionTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OSDPBench.Core.Actions;
+using OSDP.Net;
+using Moq;
+
+namespace OSDPBench.Core.Tests.Actions;
+
+[TestFixture(TestOf = typeof(MonitoringAction))]
+public class MonitoringActionTests
+{
+    [Test]
+    public void Constructor_WithCardReadsType_SetsCorrectName()
+    {
+        // Arrange & Act
+        var action = new MonitoringAction(MonitoringType.CardReads);
+        
+        // Assert
+        Assert.That(action.Name, Is.EqualTo("Monitor Card Reads"));
+        Assert.That(action.MonitoringType, Is.EqualTo(MonitoringType.CardReads));
+    }
+    
+    [Test]
+    public void Constructor_WithKeypadReadsType_SetsCorrectName()
+    {
+        // Arrange & Act
+        var action = new MonitoringAction(MonitoringType.KeypadReads);
+        
+        // Assert
+        Assert.That(action.Name, Is.EqualTo("Monitor Keypad Reads"));
+        Assert.That(action.MonitoringType, Is.EqualTo(MonitoringType.KeypadReads));
+    }
+    
+    [Test]
+    public void PerformActionName_IsEmpty()
+    {
+        // Arrange
+        var action = new MonitoringAction(MonitoringType.CardReads);
+        
+        // Act & Assert
+        Assert.That(action.PerformActionName, Is.Empty);
+    }
+    
+    [Test]
+    public async Task PerformAction_ReturnsTrue()
+    {
+        // Arrange
+        var action = new MonitoringAction(MonitoringType.CardReads);
+        
+        // Creating an actual ControlPanel would require network connections and hardware
+        // Since this is just a stub method returning a static value, we can pass null
+        
+        // Act
+        var result = await action.PerformAction(null!, Guid.NewGuid(), 1, null);
+        
+        // Assert
+        Assert.That(result, Is.EqualTo(true));
+    }
+    
+    [Test]
+    public void IsCardReadsMonitor_WithCardReadsMonitoringAction_ReturnsTrue()
+    {
+        // Arrange
+        var action = new MonitoringAction(MonitoringType.CardReads);
+        
+        // Act & Assert
+        Assert.That(action.IsCardReadsMonitor(), Is.True);
+        Assert.That(action.IsKeypadReadsMonitor(), Is.False);
+    }
+    
+    [Test]
+    public void IsKeypadReadsMonitor_WithKeypadReadsMonitoringAction_ReturnsTrue()
+    {
+        // Arrange
+        var action = new MonitoringAction(MonitoringType.KeypadReads);
+        
+        // Act & Assert
+        Assert.That(action.IsCardReadsMonitor(), Is.False);
+        Assert.That(action.IsKeypadReadsMonitor(), Is.True);
+    }
+    
+    [Test]
+    public void IsMonitoringAction_WithCorrectType_ReturnsTrue()
+    {
+        // Arrange
+        var action = new MonitoringAction(MonitoringType.CardReads);
+        
+        // Act & Assert
+        Assert.That(action.IsMonitoringAction(MonitoringType.CardReads), Is.True);
+        Assert.That(action.IsMonitoringAction(MonitoringType.KeypadReads), Is.False);
+    }
+    
+    [Test]
+    public void IsMonitoringAction_WithOtherDeviceAction_ReturnsFalse()
+    {
+        // Arrange
+        var controlBuzzerAction = new ControlBuzzerAction();
+        
+        // Act & Assert
+        Assert.That(controlBuzzerAction.IsMonitoringAction(MonitoringType.CardReads), Is.False);
+        Assert.That(controlBuzzerAction.IsMonitoringAction(MonitoringType.KeypadReads), Is.False);
+    }
+}


### PR DESCRIPTION
## Summary
- Created a unified `MonitoringAction` class with a `MonitoringType` enum to replace the nearly identical `MonitorCardReads` and `MonitorKeypadReads` classes
- Updated the `ManageViewModel` to use the new consolidated class
- Added extension methods for easier type checking (e.g., `IsCardReadsMonitor()`)
- Added comprehensive unit tests for the new class
- Updated the UI layer to handle the new consolidated class structure

## Test plan
- All unit tests pass successfully
- The Core project builds correctly
- Manual testing should be performed to confirm:
  - Card read monitoring still works correctly
  - Keypad read monitoring still works correctly
  - UI properly displays the correct controls based on the monitoring type

This PR completes item 3 from the refactoring opportunities listed in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.ai/code)